### PR TITLE
(feat): Add Virtual Contact File recipient support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 dist
 completions
 manpages
+*.vcard
+*.vcf

--- a/contact.go
+++ b/contact.go
@@ -14,7 +14,7 @@ func isContact(recipient *[]string) {
 
 			// Usually it's != nil, but if thrown an error we just leave this untouched
 			// If logger added in the future, percolate error
-			if err == nil && email != "" {
+			if err == nil && email != "" && recover() == nil {
 				(*recipient)[i] = email
 			}
 		}
@@ -27,7 +27,6 @@ func getEmail(path string) (string, error) {
 		return "", err
 	}
 	defer file.Close()
-
 	unMarshaller := vcard.NewDecoder(file)
 
 	card, err := unMarshaller.Decode()

--- a/contact.go
+++ b/contact.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"strings"
+
+	vcard "github.com/emersion/go-vcard"
+)
+
+func isContact(recipient *[]string) {
+	for i, contact := range *recipient {
+		if strings.HasSuffix(contact, ".vcf") || strings.HasSuffix(contact, ".vcard") {
+			email, err := getEmail(contact)
+
+			// Usually it's != nil, but if thrown an error we just leave this untouched
+			// If logger added in the future, percolate error
+			if err == nil && email != "" {
+				(*recipient)[i] = email
+			}
+		}
+	}
+}
+
+func getEmail(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	unMarshaller := vcard.NewDecoder(file)
+
+	card, err := unMarshaller.Decode()
+	if err != nil {
+		return "", err
+	}
+	email := card.PreferredValue(vcard.FieldEmail)
+
+	return email, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v0.16.2-0.20230711184233-0bdcc628fb8f
 	github.com/charmbracelet/bubbletea v0.24.3-0.20230710130425-c4c83ba757f8
 	github.com/charmbracelet/lipgloss v0.7.1
+	github.com/emersion/go-vcard v0.0.0-20230626131229-38c18b295bbd
 	github.com/muesli/mango-cobra v1.2.0
 	github.com/muesli/roff v0.1.0
 	github.com/resendlabs/resend-go v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/emersion/go-vcard v0.0.0-20230626131229-38c18b295bbd h1:n1kH4lDJLDgO8sqkt0QgeQXKims1L8khdgilk9G5lm8=
+github.com/emersion/go-vcard v0.0.0-20230626131229-38c18b295bbd/go.mod h1:HMJKR5wlh/ziNp+sHEDV2ltblO4JD2+IdDOWtGcQBTM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=

--- a/main.go
+++ b/main.go
@@ -51,6 +51,9 @@ var rootCmd = &cobra.Command{
 			body += "\n\n" + signature
 		}
 
+		// Check if the recepient is a contact card, and grab first email if so
+		isContact(&to)
+
 		if len(to) > 0 && from != "" && subject != "" && body != "" && !preview {
 			err := sendEmail(to, from, subject, body, attachments)
 			if err != nil {


### PR DESCRIPTION
Giving the path to a `.vcard` or `.vcf` file instead of a recipient's email address fills in the first email from the vCard.