### PR TITLE
(docs): Remove duplicate License section in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,6 @@ pop --attach $FILENAME --body "See attached invoice."
 
 - [`maaslalani/invoice`](https://github.com/maaslalani/invoice)
 
-## License
-
-[MIT](https://github.com/charmbracelet/pop/blob/main/LICENSE)
-
 ## Feedback
 
 We’d love to hear your thoughts on this project. Feel free to drop us a note!
@@ -140,7 +136,7 @@ We’d love to hear your thoughts on this project. Feel free to drop us a note!
 
 ## License
 
-[MIT](https://github.com/charmbracelet/pop/raw/main/LICENSE)
+[MIT](https://github.com/charmbracelet/pop/blob/main/LICENSE)
 
 ---
 


### PR DESCRIPTION
Hello everyone! 👋 

I noticed the License section, in the README.md, being mentioned twice, so I removed the second instance which had the ["/raw/" URL](https://raw.githubusercontent.com/charmbracelet/pop/main/LICENSE), that was causing the issue. 
The primary License section has been updated to use the ["/blob/" URL format](https://github.com/charmbracelet/pop/blob/main/LICENSE).