### PR TITLE
Store email body on failed send 

### DIFF
--- a/email.go
+++ b/email.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,6 +49,11 @@ func (m Model) sendEmailCmd() tea.Cmd {
 			err = errors.New("[ERROR]: unknown delivery method")
 		}
 		if err != nil {
+			// Store the body if the email fails to send
+			path, storeErr := storeEmailBody(m.Body.Value())
+			if storeErr == nil {
+				err = fmt.Errorf("%w\nStored a copy of the email body at %s", err, path)
+			}
 			return sendEmailFailureMsg(err)
 		}
 		return sendEmailSuccessMsg{}
@@ -182,4 +188,40 @@ func makeAttachments(paths []string) []resend.Attachment {
 	}
 
 	return attachments
+}
+
+// Store the email body in /tmp. Returns a path to the file created.
+func storeEmailBody(body string) (string, error) {
+	dir := "/tmp/pop"
+
+	err := os.MkdirAll(dir, 0700)
+	if err != nil {
+		return "", fmt.Errorf("creating %s: %w", dir, err)
+	}
+
+	curr := time.Now()
+	fileName := fmt.Sprintf("%d-%d-%d-%d", curr.Year(), curr.Month(), curr.Day(), secondsSinceDayStart(curr))
+	fullPath := filepath.Join(dir, fileName)
+
+	file, err := os.Create(fullPath)
+	if err != nil {
+		return "", fmt.Errorf("creating %s: %w", fullPath, err)
+	}
+	defer file.Close()
+
+	_, err = file.Write([]byte(body))
+	if err != nil {
+		return "", fmt.Errorf("writing to %s: %w", fullPath, err)
+	}
+
+	return fullPath, nil
+}
+
+// Returns the seconds passed since the start of t.
+// The start of t is determined as y:m:d:0:0:0:0
+func secondsSinceDayStart(t time.Time) int {
+	y, m, d := t.Date()
+	start := time.Date(y, m, d, 0, 0, 0, 0, t.Location())
+	elapsed := time.Since(start)
+	return int(elapsed.Seconds())
 }

--- a/model.go
+++ b/model.go
@@ -213,7 +213,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.state = editingFrom
 		m.focusActiveInput()
 		m.err = msg
-		return m, clearErrAfter(5 * time.Second)
+		return m, clearErrAfter(10 * time.Second)
 	case clearErrMsg:
 		m.err = nil
 	case tea.KeyMsg:


### PR DESCRIPTION
This is an implementation of #45 

When an email fails to send, the body is saved to the `/tmp/pop` dir with a filename in the format `y-m-d-timeStamp`. I also updated the error message to display the path of the file created and increased the error display time. 

It's now possible to run a command similar to what @maaslalani suggested. 

```shell
pop < /tmp/pop/2024-1-24-61319
```

This prevents users having to retype lengthy emails when a send fails and pop must be closed to address the send error.