### PR TITLE
Correct mods example

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Use [`mods`](https://github.com/charmbracelet/mods) with `pop` to write an email
 > Use the `--preview` flag to preview the email and make changes before sending.
 
 ```bash
-pop <<< '$(mods -f "Explain why CLIs are awesome")' \
+pop <<< "$(mods -f 'Explain why CLIs are awesome')" \
     --subject "The command line is the best" \
     --preview
 ```


### PR DESCRIPTION
Usage of single quotes around `'$(mods -f "Explain why CLIs are awesome")'` causes the command to be treated as a string instead of being executed.  Updated to double quotes, now aligns with what's shown in the gif.