### PR TITLE
fixes charmbracelet/pop#136

### DIFF
--- a/email.go
+++ b/email.go
@@ -82,6 +82,11 @@ func sendSMTPEmail(to, cc, bcc []string, from, subject, body string, attachments
 		}
 	}
 
+	// If no authentication is provided, disable it for internal mail relays
+	if server.Username == "" && server.Password == "" {
+		server.Authentication = mail.AuthNone
+	}
+
 	switch strings.ToLower(smtpEncryption) {
 	case "ssl":
 		server.Encryption = mail.EncryptionSSLTLS

--- a/main.go
+++ b/main.go
@@ -85,6 +85,9 @@ var rootCmd = &cobra.Command{
 			if from == "" {
 				from = smtpUsername
 			}
+		case smtpHost != "":
+			// Allow SMTP delivery with just host for internal mail relays (no auth)
+			deliveryMethod = SMTP
 		}
 
 		switch deliveryMethod {


### PR DESCRIPTION
### Describe your changes
Handles the case that there is no auth needed for SMTP, e.g. for internal mailrelays

### Related issue/discussion: https://github.com/charmbracelet/pop/issues/136

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
