### PR TITLE
fix: prevent wrapping nil error on successful SMTP delivery

### DIFF
--- a/email.go
+++ b/email.go
@@ -129,11 +129,9 @@ func sendSMTPEmail(to, cc, bcc []string, from, subject, body string, attachments
 		})
 	}
 
-	err = email.Send(smtpClient)
-	if err != nil {
+	if err := email.Send(smtpClient); err != nil {
 		return fmt.Errorf("sending email: %w", err)
 	}
-
 	return nil
 }
 

--- a/email.go
+++ b/email.go
@@ -129,7 +129,12 @@ func sendSMTPEmail(to, cc, bcc []string, from, subject, body string, attachments
 		})
 	}
 
-	return fmt.Errorf("sending email: %w", email.Send(smtpClient))
+	err = email.Send(smtpClient)
+	if err != nil {
+		return fmt.Errorf("sending email: %w", err)
+	}
+
+	return nil
 }
 
 func sendResendEmail(to, cc, bcc []string, from, subject, body string, attachments []string) error {


### PR DESCRIPTION
### Description
Fixes a regression introduced during a recent refactoring or linting pass where a successful SMTP delivery returns a `sending email: %!w(<nil>)` error message. 

This PR adds an explicit `nil` check before attempting to annotate the error with context.

### Changes
* Intercept the error returned by the mail delivery client.
* Return `nil` immediately if the delivery was successful.
* Only wrap and return the error with `fmt.Errorf` if an actual failure occurred.

### Verification
* Verified locally with Google SMTP. 
* Successful emails are sent cleanly without emitting `%!w(<nil>)` to stderr, and the process exits with status `0`.

---

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
