### PR TITLE
Add builtin skill, skill installers, and generally make Pop agent-friendly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ Pop can generate and install skill definitions for AI agents:
 - `pop install-skill <target>` — Installs to a specific agent's rules directory
 
 The skill body lives in `skill.md` and is embedded at build time via
-`//go:embed`. Supported targets: `crush`, `claude`, `codex`, `cursor`. Each
+`//go:embed`. Supported targets: `crush`, `claude`, `codex`, `cursor`, `pi`. Each
 target writes to the correct path and format for that agent.
 
 ## Conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,142 @@
+# AGENTS.md
+
+Guide for AI agents working on the Pop codebase.
+
+## What is Pop?
+
+Pop is a command-line email client built in Go. It supports two delivery methods
+— Resend (OAuth or API key) and SMTP — and provides both an interactive TUI
+(Bubble Tea) and non-interactive CLI sending.
+
+## Build & Development Commands
+
+```bash
+task build       # Build the project
+task lint        # Run golangci-lint (strict config in .golangci.yml)
+task lint:fix    # Auto-fix lint issues
+task vet         # Run go vet
+task test        # Run tests
+task fmt         # Format code (gofumpt + goimports)
+task tidy        # Tidy go modules
+task             # Run the project (go run . {{.CLI_ARGS}})
+```
+
+Always run `task lint` before committing. The linter enables `gofumpt` and
+`goimports` formatters, `wrapcheck` (errors from external packages must be
+wrapped with `fmt.Errorf("...: %w", err)`), `goconst` (repeated string literals
+should be constants), `gosec`, `revive`, and others.
+
+## Architecture
+
+### Source Layout
+
+All source files are in the package root (no sub-packages):
+
+- `main.go` — Root cobra command, flag definitions, delivery method detection,
+  non-interactive send path
+- `model.go` — Bubble Tea TUI model (`Model`), state machine, view rendering
+- `keymap.go` — TUI key bindings and help
+- `email.go` — Email sending logic (SMTP via go-simple-mail, Resend via
+  resend-go), Markdown-to-HTML conversion (goldmark)
+- `attachments.go` — Attachment list item type and delegate for the TUI
+- `auth.go` — OAuth 2.0 with PKCE: token storage, client registration, token
+  exchange, refresh, callback server
+- `auth_cli.go` — Non-interactive OAuth flow (stdin not a terminal)
+- `auth_ui.go` — Interactive OAuth flow (Bubble Tea TUI with spinner states)
+- `style.go` — Lipgloss styles and charmtone color palette
+- `skill.go` — `pop skill` command (prints skill definition)
+- `skill.md` — Embedded skill body (via `go:embed`)
+- `install_skill.go` — `pop install-skill` command with per-agent subcommands
+
+### CLI vs TUI
+
+The root command's `RunE` determines whether to send non-interactively or launch
+the TUI:
+
+- **Non-interactive**: All of `--to`, `--from`, `--subject`, and a body are
+  provided AND `--preview` is not set. Sends immediately.
+- **TUI**: Launched when any required field is missing or stdin is a terminal
+  with no piped body.
+
+### Delivery Methods
+
+Pop auto-detects the delivery method from environment and flags in `main.go`:
+
+- `Resend` — via `RESEND_API_KEY` env, `--resend.key` flag, or OAuth token from
+  `pop auth`
+- `SMTP` — via `POP_SMTP_*` environment variables or `--smtp.*` flags
+- Setting both is an error (`Unknown` delivery method)
+
+### OAuth Flow
+
+OAuth uses PKCE with Resend's OAuth 2.0 API:
+
+1. Dynamic client registration (`POST /oauth/register`)
+2. Start local callback server on `127.0.0.1`
+3. Open browser for authorization
+4. Exchange code for tokens
+5. Persist tokens to `auth.json` in the user config dir
+
+Two entry points:
+
+- **TUI** (`auth_ui.go`): `startOAuthFlowTUI()` — interactive Bubble Tea program
+  with spinner states (intro → preparing → waiting → exchanging → done/error)
+- **CLI** (`auth_cli.go`): `startOAuthFlow()` — plain stdout, used when stdin is
+  not a terminal
+
+Token refresh happens automatically in `getValidAccessToken()` before each send
+if the token is within 5 minutes of expiry.
+
+### Colors and Styling
+
+Pop uses the **charmtone** color palette
+(`github.com/charmbracelet/x/exp/charmtone`) for all colors, not raw hex values.
+See `style.go` for the full set of named colors (Charple, Zest, Soda, Steam,
+etc.).
+
+**All CLI-based styled output (not Bubble Tea views) must go through a
+`colorprofile` writer** to handle terminal color downsampling correctly:
+
+```go
+w := colorprofile.NewWriter(os.Stderr, os.Environ())
+_, _ = fmt.Fprintf(w, "...")
+```
+
+Bubble Tea applies colorprofile automatically to its rendered output, so TUI
+views don't need this. This is only for direct `fmt.Fprintf`/`fmt.Println`
+calls to stdout/stderr outside of a Bubble Tea program. See `main.go` and
+`install_skill.go` for examples.
+
+Error messages follow a consistent pattern:
+
+```
+\n  ERROR  <message>\n\n
+```
+
+Use `errorHeaderStyle` for the badge and `inlineCodeStyle` for code/paths. Set
+`cmd.SilenceUsage = true` and `cmd.SilenceErrors = true` in cobra `RunE` when
+printing custom errors.
+
+### Skills
+
+Pop can generate and install skill definitions for AI agents:
+
+- `pop skill` — Prints the skill to stdout (Crush-compatible YAML frontmatter +
+  markdown body)
+- `pop install-skill <target>` — Installs to a specific agent's rules directory
+
+The skill body lives in `skill.md` and is embedded at build time via
+`//go:embed`. Supported targets: `crush`, `claude`, `codex`, `cursor`. Each
+target writes to the correct path and format for that agent.
+
+## Conventions
+
+- Use `gofumpt` formatting (stricter than `gofmt`)
+- Wrap all errors from external packages with `fmt.Errorf("context: %w", err)`
+  (wrapcheck)
+- Extract repeated string literals to constants (goconst)
+- Use `charmtone` colors, never raw hex
+- Use `colorprofile.NewWriter` for all styled terminal output
+- Check `_, _ =` on `fmt.Fprintf` to errWriter (errcheck)
+- File permissions: `0o750` for directories, `0o600` for files (gosec)
+- Use `//nolint:gosec // reason` or `//nolint:mnd` only where truly needed

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ going, but you can maximize their `pop` abilities with the builtin `pop skill`
 command, which you can just print to `stdout`, or write to disk:
 
 ```bash
-mkdir -p ./.skills/pop
-pop skill > ./skills/pop/SKILL.md
+mkdir -p .skills/pop
+pop skill > .skills/pop/SKILL.md
 ```
 
 If you’re using [Crush](https://github.com/charmbracelet/crush), Claude Code,

--- a/README.md
+++ b/README.md
@@ -102,6 +102,26 @@ go install github.com/charmbracelet/pop@latest
 Or download a binary from the
 [releases](https://github.com/charmbracelet/pop/releases).
 
+## AI Agents and Skills
+
+AI agents work great with `pop`. `pop --help` is typically enough to get them
+going, but you can maximize their `pop` abilities with the builtin `pop skill`
+command, which you can just print to `stdout`, or write to disk:
+
+```bash
+mkdir -p ./.skills/pop
+pop skill > ./skills/pop/SKILL.md
+```
+
+If you’re using [Crush](https://github.com/charmbracelet/crush), Claude Code,
+Codex, or Cursor, or Pi there’s also a `pop install-skill` command
+
+```bash
+pop install-skill crush  # install the Crush skill
+pop install-skill codex  # install the Codex skill
+pop install-skill --help # more info
+```
+
 ## Examples
 
 Pop can be combined with other tools to create powerful email pipelines, such
@@ -125,9 +145,9 @@ pop <<< "$(crush run 'Explain why CLIs are awesome')" \
     --preview
 ```
 
-<img width="600" src="https://vhs.charm.sh/vhs-1O3zo8Nsi2kPVW3vOBw4WH.gif" alt="Generate email with mods and send email with pop.">
+<img width="600" src="https://vhs.charm.sh/vhs-1O3zo8Nsi2kPVW3vOBw4WH.gif" alt="Generate email with Crush and send email with Pop.">
 
-- [`charmbracelet/mods`](https://github.com/charmbracelet/mods)
+- [`charmbracelet/crush`](https://github.com/charmbracelet/crush)
 
 ### Gum
 

--- a/auth.go
+++ b/auth.go
@@ -75,9 +75,6 @@ func loadAuth() (*OAuthToken, error) {
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, err
-		}
 		return nil, fmt.Errorf("reading auth file: %w", err)
 	}
 	var token OAuthToken

--- a/auth.go
+++ b/auth.go
@@ -75,6 +75,9 @@ func loadAuth() (*OAuthToken, error) {
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, err //nolint:wrapcheck // caller checks os.IsNotExist
+		}
 		return nil, fmt.Errorf("reading auth file: %w", err)
 	}
 	var token OAuthToken

--- a/install_skill.go
+++ b/install_skill.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// Skill install targets.
+const (
+	targetCrush  = "crush"
+	targetClaude = "claude"
+	targetCodex  = "codex"
+	targetCursor = "cursor"
+)
+
+// skillInstaller resolves the destination path and formats content for a given agent.
+type skillInstaller struct {
+	path    func() (string, error)
+	content func() string
+}
+
+// crushSkillContent returns the standard Crush/Claude skill format.
+func crushSkillContent() string {
+	return popSkill
+}
+
+// cursorSkillContent returns the Cursor .mdc format with cursor-compatible frontmatter.
+func cursorSkillContent() string {
+	return "---\n" +
+		"description: '" + popSkillDescription + "'\n" +
+		"globs:\n" +
+		"alwaysApply: false\n" +
+		"---\n\n" +
+		popSkillBody
+}
+
+var skillInstallers = map[string]skillInstaller{
+	targetCrush: {
+		path: func() (string, error) {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("resolving home directory: %w", err)
+			}
+			return filepath.Join(home, ".config", "crush", "skills", "pop", "SKILL.md"), nil
+		},
+		content: crushSkillContent,
+	},
+	targetClaude: {
+		path: func() (string, error) {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("resolving home directory: %w", err)
+			}
+			return filepath.Join(home, ".claude", "skills", "pop", "SKILL.md"), nil
+		},
+		content: crushSkillContent,
+	},
+	targetCursor: {
+		path: func() (string, error) {
+			return filepath.Join(".cursor", "rules", "pop.mdc"), nil
+		},
+		content: cursorSkillContent,
+	},
+	targetCodex: {
+		path: func() (string, error) {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("resolving home directory: %w", err)
+			}
+			return filepath.Join(home, ".codex", "AGENTS.md"), nil
+		},
+		content: func() string { return popSkillBody },
+	},
+}
+
+// skillDisplayNames maps internal target names to their product display names.
+var skillDisplayNames = map[string]string{
+	targetCrush:  "Charm Crush",
+	targetClaude: "Claude Code",
+	targetCodex:  "OpenAI Codex",
+	targetCursor: "Cursor",
+}
+
+// skillTargetOrder is the order targets appear in help output.
+var skillTargetOrder = []string{targetCrush, targetClaude, targetCodex, targetCursor}
+
+var installSkillForce bool
+
+// InstallSkillCmd is the parent command for installing the pop skill to AI agents.
+var InstallSkillCmd = &cobra.Command{
+	Use:   "install-skill",
+	Short: "Install the Pop skill for AI agents",
+	Long:  `Install the Pop skill definition for an AI agent.`,
+	Args:  cobra.NoArgs,
+}
+
+// newInstallSkillTargetCmd creates a subcommand for installing to a specific agent.
+func newInstallSkillTargetCmd(target string) *cobra.Command {
+	name := skillDisplayNames[target]
+	short := fmt.Sprintf("Install the Pop skill for %s", name)
+	if target == targetCursor {
+		short = fmt.Sprintf("Install the Pop skill for %s (in the current directory)", name)
+	}
+	return &cobra.Command{
+		Use:   target,
+		Short: short,
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return installSkill(target)
+		},
+	}
+}
+
+func installSkill(target string) error {
+	name := skillDisplayNames[target]
+	inst := skillInstallers[target]
+	path, err := inst.path()
+	if err != nil {
+		fmt.Printf("  %s Failed to resolve path for %s: %s\n",
+			errorHeaderStyle.String(), name, err)
+		return fmt.Errorf("resolving path: %w", err)
+	}
+
+	if _, err := os.Stat(path); err == nil && !installSkillForce {
+		fmt.Printf("  %s Already installed at %s (use --force to overwrite)\n",
+			errorHeaderStyle.String(),
+			path)
+		return fmt.Errorf("skill already installed")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		fmt.Printf("  %s Failed to create directory for %s: %s\n",
+			errorHeaderStyle.String(), name, err)
+		return fmt.Errorf("creating directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, []byte(inst.content()), 0o600); err != nil {
+		fmt.Printf("  %s Failed to write %s: %s\n",
+			errorHeaderStyle.String(), name, err)
+		return fmt.Errorf("writing skill: %w", err)
+	}
+
+	fmt.Printf("  %s Installed skill to %s\n",
+		activeLabelStyle.Render("OK"),
+		path)
+	return nil
+}
+
+func init() {
+	InstallSkillCmd.PersistentFlags().BoolVarP(&installSkillForce, "force", "f", false, "Overwrite existing skill files")
+	cobra.EnableCommandSorting = false
+	for _, target := range skillTargetOrder {
+		InstallSkillCmd.AddCommand(newInstallSkillTargetCmd(target))
+	}
+}

--- a/install_skill.go
+++ b/install_skill.go
@@ -16,6 +16,7 @@ const (
 	targetClaude = "claude"
 	targetCodex  = "codex"
 	targetCursor = "cursor"
+	targetPi     = "pi"
 )
 
 // skillInstaller resolves the destination path and formats content for a given agent.
@@ -32,6 +33,9 @@ func tildePath(path string) string {
 	}
 	if path == home {
 		return "~"
+	}
+	if !strings.HasPrefix(path, home) {
+		return path
 	}
 	return "~" + strings.TrimPrefix(path, home)
 }
@@ -88,6 +92,12 @@ var skillInstallers = map[string]skillInstaller{
 		},
 		content: func() string { return popSkillBody },
 	},
+	targetPi: {
+		path: func() (string, error) {
+			return filepath.Join(".pi", "skills", "pop.md"), nil
+		},
+		content: crushSkillContent,
+	},
 }
 
 // skillDisplayNames maps internal target names to their product display names.
@@ -96,10 +106,11 @@ var skillDisplayNames = map[string]string{
 	targetClaude: "Claude Code",
 	targetCodex:  "OpenAI Codex",
 	targetCursor: "Cursor",
+	targetPi:     "Pi",
 }
 
 // skillTargetOrder is the order targets appear in help output.
-var skillTargetOrder = []string{targetCrush, targetClaude, targetCodex, targetCursor}
+var skillTargetOrder = []string{targetCrush, targetClaude, targetCodex, targetCursor, targetPi}
 
 var installSkillForce bool
 
@@ -115,7 +126,7 @@ var InstallSkillCmd = &cobra.Command{
 func newInstallSkillTargetCmd(target string) *cobra.Command {
 	name := skillDisplayNames[target]
 	short := fmt.Sprintf("Install the Pop skill for %s", name)
-	if target == targetCursor {
+	if target == targetCursor || target == targetPi {
 		short = fmt.Sprintf("Install the Pop skill for %s (in the current directory)", name)
 	}
 	return &cobra.Command{

--- a/install_skill.go
+++ b/install_skill.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/charmbracelet/colorprofile"
 	"github.com/spf13/cobra"
 )
 
@@ -20,6 +22,18 @@ const (
 type skillInstaller struct {
 	path    func() (string, error)
 	content func() string
+}
+
+// tildePath replaces the home directory prefix with ~/ for display.
+func tildePath(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == home {
+		return "~"
+	}
+	return "~" + strings.TrimPrefix(path, home)
 }
 
 // crushSkillContent returns the standard Crush/Claude skill format.
@@ -108,44 +122,45 @@ func newInstallSkillTargetCmd(target string) *cobra.Command {
 		Use:   target,
 		Short: short,
 		Args:  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
 			return installSkill(target)
 		},
 	}
 }
 
 func installSkill(target string) error {
-	name := skillDisplayNames[target]
+	const gap = "  "
+	w := colorprofile.NewWriter(os.Stderr, os.Environ())
 	inst := skillInstallers[target]
 	path, err := inst.path()
 	if err != nil {
-		fmt.Printf("  %s Failed to resolve path for %s: %s\n",
-			errorHeaderStyle.String(), name, err)
+		_, _ = fmt.Fprintf(w, "\n%s%s %s\n\n", gap, errorHeaderStyle.String(), err)
 		return fmt.Errorf("resolving path: %w", err)
 	}
 
 	if _, err := os.Stat(path); err == nil && !installSkillForce {
-		fmt.Printf("  %s Already installed at %s (use --force to overwrite)\n",
-			errorHeaderStyle.String(),
-			path)
+		_, _ = fmt.Fprintf(w, "\n%s%s Skill already installed at %s\n\n",
+			gap, errorHeaderStyle.String(),
+			inlineCodeStyle.Render(tildePath(path)))
+		_, _ = fmt.Fprintf(w, "%sTo overwrite, use %s.\n\n", gap, inlineCodeStyle.Render("--force"))
 		return fmt.Errorf("skill already installed")
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		fmt.Printf("  %s Failed to create directory for %s: %s\n",
-			errorHeaderStyle.String(), name, err)
+		_, _ = fmt.Fprintf(w, "\n%s%s %s\n\n", gap, errorHeaderStyle.String(), err)
 		return fmt.Errorf("creating directory: %w", err)
 	}
 
 	if err := os.WriteFile(path, []byte(inst.content()), 0o600); err != nil {
-		fmt.Printf("  %s Failed to write %s: %s\n",
-			errorHeaderStyle.String(), name, err)
+		_, _ = fmt.Fprintf(w, "\n%s%s %s\n\n", gap, errorHeaderStyle.String(), err)
 		return fmt.Errorf("writing skill: %w", err)
 	}
 
-	fmt.Printf("  %s Installed skill to %s\n",
+	_, _ = fmt.Fprintf(w, "  %s Installed skill to %s\n",
 		activeLabelStyle.Render("OK"),
-		path)
+		tildePath(path))
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -89,7 +89,21 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "pop",
 	Short: "Send emails from your terminal",
-	Long:  `Pop is a tool for sending emails from your terminal.`,
+	Long: `Pop is a tool for sending emails from your terminal.
+
+Run with no arguments to launch the interactive TUI:
+
+  pop
+
+Send non-interactively by providing all required flags (no TUI):
+
+  pop < message.md \
+      --from me@example.com \
+      --to you@example.com \
+      --subject "Hello, world!" \
+      --attach invoice.pdf
+
+See "pop skill" for a full skill definition for AI agents.`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		var deliveryMethod DeliveryMethod
 		switch {
@@ -352,6 +366,7 @@ var RevokeCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(ManCmd)
 	rootCmd.AddCommand(AuthCmd)
+	rootCmd.AddCommand(SkillCmd)
 	AuthCmd.AddCommand(RevokeCmd)
 	AuthCmd.Flags().BoolVar(&oauthNoBrowser, "no-browser", false, "Simulate browser open failure (for testing)")
 

--- a/main.go
+++ b/main.go
@@ -91,11 +91,8 @@ var rootCmd = &cobra.Command{
 	Short: "Send emails from your terminal",
 	Long: `Pop is a tool for sending emails from your terminal.
 
-Run with no arguments to launch the interactive TUI:
-
-  pop
-
-Send non-interactively by providing all required flags (no TUI):
+Run with no arguments to launch the interactive TUI, or send email
+non-interactively on the CLI by providing all required flags:
 
   pop < message.md \
       --from me@example.com \
@@ -367,6 +364,7 @@ func init() {
 	rootCmd.AddCommand(ManCmd)
 	rootCmd.AddCommand(AuthCmd)
 	rootCmd.AddCommand(SkillCmd)
+	rootCmd.AddCommand(InstallSkillCmd)
 	AuthCmd.AddCommand(RevokeCmd)
 	AuthCmd.Flags().BoolVar(&oauthNoBrowser, "no-browser", false, "Simulate browser open failure (for testing)")
 

--- a/skill.go
+++ b/skill.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// popSkill is the Crush-compatible skill definition that teaches AI agents
+// how to use pop non-interactively.
+const popSkill = `---
+name: pop
+description: Send emails from the terminal with the pop CLI. Use when the user asks to send, draft, or compose an email non-interactively, attach files to an email, configure email delivery via Resend or SMTP, or asks about pop commands and environment variables. Triggers on mentions of "pop" in the context of email, mailing, SMTP, or Resend.
+---
+
+# Pop — Send Email from the Terminal
+
+Pop is a command-line tool for sending email. This skill covers non-interactive usage.
+
+## Setup
+
+Pop supports three delivery methods. Configure exactly one.
+
+### Resend OAuth (recommended)
+
+    pop auth
+
+Authenticates with Resend via OAuth 2.0 in the browser. Tokens are stored locally and reused automatically on subsequent sends, so this only needs to be run once.
+
+Revoke with:
+
+    pop auth revoke
+
+### Resend API Key
+
+Set RESEND_API_KEY in the environment, or pass --resend.key.
+
+    export RESEND_API_KEY=re_xxxxxxxx
+
+### SMTP
+
+    export POP_SMTP_HOST=smtp.gmail.com
+    export POP_SMTP_PORT=587
+    export POP_SMTP_USERNAME=you@example.com
+    export POP_SMTP_PASSWORD=secret
+    export POP_SMTP_ENCRYPTION=starttls
+
+Encryption options: starttls (default), ssl, none.
+
+### Other Environment Variables
+
+    POP_FROM          Default sender address
+    POP_SIGNATURE     Signature appended to the email body
+    POP_UNSAFE_HTML   Set to "true" to allow unsafe HTML and extra markdown features
+
+## Sending Email (Non-Interactive)
+
+When --to, --from, --subject, and a body are ALL provided and --preview is NOT set, Pop sends immediately without launching the TUI.
+
+Body via stdin:
+
+    pop < message.md --from me@example.com --to you@example.com --subject "Hello"
+
+Body via flag:
+
+    pop --body "Hello there" --from me@example.com --to you@example.com --subject "Hello"
+
+### Flags
+
+    -f, --from         Sender address (env POP_FROM)
+    -t, --to           Recipients (comma-separated or repeatable)
+        --cc           CC recipients
+        --bcc          BCC recipients
+    -s, --subject      Email subject
+    -b, --body         Email body (Markdown, rendered to HTML)
+    -a, --attach       Attach a file (repeatable)
+    -x, --signature    Signature appended to body (env POP_SIGNATURE)
+    -u, --unsafe       Allow unsafe HTML / extra markdown features (env POP_UNSAFE_HTML)
+        --preview      Open the TUI to review before sending
+
+### Attachments
+
+    pop --attach invoice.pdf --attach report.docx \
+        --from me@example.com --to client@example.com \
+        --subject "Documents" --body "See attached."
+
+## Composing with Other Tools
+
+Pipe generated content from another CLI tool into pop:
+
+    pop <<< "$(crush run 'Write a welcome email')" \
+        --subject "Welcome" --from me@example.com --to you@example.com
+
+## Notes
+
+- The body is Markdown, rendered to HTML before sending.
+- If both Resend and SMTP are configured, Pop errors — set only one.
+- Gmail users: host/port default automatically when the username ends in @gmail.com.
+- If --preview is set or any required field is missing, the interactive TUI launches instead.
+`
+
+// SkillCmd prints a Crush-compatible skill definition to stdout so AI agents
+// can discover and use pop non-interactively.
+var SkillCmd = &cobra.Command{
+	Use:   "skill",
+	Short: "Print a skill definition for AI agents",
+	Long:  `Print a Crush-compatible skill that teaches AI agents how to use pop non-interactively.`,
+	Args:  cobra.NoArgs,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		fmt.Print(popSkill)
+		return nil
+	},
+}

--- a/skill.go
+++ b/skill.go
@@ -25,7 +25,7 @@ var popSkill = "---\n" +
 var SkillCmd = &cobra.Command{
 	Use:   "skill",
 	Short: "Print a skill definition for AI agents",
-	Long:  `Print a Crush-compatible skill that teaches AI agents how to use pop non-interactively.`,
+	Long:  `Print a skill that teaches AI agents how to use Pop non-interactively.`,
 	Args:  cobra.NoArgs,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		fmt.Print(popSkill)

--- a/skill.go
+++ b/skill.go
@@ -8,7 +8,7 @@ import (
 )
 
 // popSkillDescription is the description used in skill frontmatter.
-const popSkillDescription = `Send emails from the terminal with the pop CLI. Use when the user asks to send, draft, or compose an email non-interactively, attach files to an email, configure email delivery via Resend or SMTP, or asks about pop commands and environment variables. Triggers on mentions of "pop" in the context of email, mailing, SMTP, or Resend.`
+const popSkillDescription = `Send emails from the terminal. Use when the user asks to send, draft, or compose an email, attach files to an email, configure email delivery via Resend or SMTP, or asks about pop commands and environment variables. Triggers on mentions of "pop" in the context of email, mailing, SMTP, or Resend.`
 
 //go:embed skill.md
 var popSkillBody string

--- a/skill.go
+++ b/skill.go
@@ -1,103 +1,24 @@
 package main
 
 import (
+	_ "embed"
 	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
-// popSkill is the Crush-compatible skill definition that teaches AI agents
-// how to use pop non-interactively.
-const popSkill = `---
-name: pop
-description: Send emails from the terminal with the pop CLI. Use when the user asks to send, draft, or compose an email non-interactively, attach files to an email, configure email delivery via Resend or SMTP, or asks about pop commands and environment variables. Triggers on mentions of "pop" in the context of email, mailing, SMTP, or Resend.
----
+// popSkillDescription is the description used in skill frontmatter.
+const popSkillDescription = `Send emails from the terminal with the pop CLI. Use when the user asks to send, draft, or compose an email non-interactively, attach files to an email, configure email delivery via Resend or SMTP, or asks about pop commands and environment variables. Triggers on mentions of "pop" in the context of email, mailing, SMTP, or Resend.`
 
-# Pop — Send Email from the Terminal
+//go:embed skill.md
+var popSkillBody string
 
-Pop is a command-line tool for sending email. This skill covers non-interactive usage.
-
-## Setup
-
-Pop supports three delivery methods. Configure exactly one.
-
-### Resend OAuth (recommended)
-
-    pop auth
-
-Authenticates with Resend via OAuth 2.0 in the browser. Tokens are stored locally and reused automatically on subsequent sends, so this only needs to be run once.
-
-Revoke with:
-
-    pop auth revoke
-
-### Resend API Key
-
-Set RESEND_API_KEY in the environment, or pass --resend.key.
-
-    export RESEND_API_KEY=re_xxxxxxxx
-
-### SMTP
-
-    export POP_SMTP_HOST=smtp.gmail.com
-    export POP_SMTP_PORT=587
-    export POP_SMTP_USERNAME=you@example.com
-    export POP_SMTP_PASSWORD=secret
-    export POP_SMTP_ENCRYPTION=starttls
-
-Encryption options: starttls (default), ssl, none.
-
-### Other Environment Variables
-
-    POP_FROM          Default sender address
-    POP_SIGNATURE     Signature appended to the email body
-    POP_UNSAFE_HTML   Set to "true" to allow unsafe HTML and extra markdown features
-
-## Sending Email (Non-Interactive)
-
-When --to, --from, --subject, and a body are ALL provided and --preview is NOT set, Pop sends immediately without launching the TUI.
-
-Body via stdin:
-
-    pop < message.md --from me@example.com --to you@example.com --subject "Hello"
-
-Body via flag:
-
-    pop --body "Hello there" --from me@example.com --to you@example.com --subject "Hello"
-
-### Flags
-
-    -f, --from         Sender address (env POP_FROM)
-    -t, --to           Recipients (comma-separated or repeatable)
-        --cc           CC recipients
-        --bcc          BCC recipients
-    -s, --subject      Email subject
-    -b, --body         Email body (Markdown, rendered to HTML)
-    -a, --attach       Attach a file (repeatable)
-    -x, --signature    Signature appended to body (env POP_SIGNATURE)
-    -u, --unsafe       Allow unsafe HTML / extra markdown features (env POP_UNSAFE_HTML)
-        --preview      Open the TUI to review before sending
-
-### Attachments
-
-    pop --attach invoice.pdf --attach report.docx \
-        --from me@example.com --to client@example.com \
-        --subject "Documents" --body "See attached."
-
-## Composing with Other Tools
-
-Pipe generated content from another CLI tool into pop:
-
-    pop <<< "$(crush run 'Write a welcome email')" \
-        --subject "Welcome" --from me@example.com --to you@example.com
-
-## Notes
-
-- The body is Markdown, rendered to HTML before sending.
-- If both Resend and SMTP are configured, Pop errors — set only one.
-- Gmail users: host/port default automatically when the username ends in @gmail.com.
-- If --preview is set or any required field is missing, the interactive TUI launches instead.
-`
+// popSkill is the full Crush-compatible skill definition (frontmatter + body).
+var popSkill = "---\n" +
+	"name: pop\n" +
+	"description: '" + popSkillDescription + "'\n" +
+	"---\n\n" +
+	popSkillBody
 
 // SkillCmd prints a Crush-compatible skill definition to stdout so AI agents
 // can discover and use pop non-interactively.

--- a/skill.md
+++ b/skill.md
@@ -1,0 +1,90 @@
+# Pop — Send Email from the Terminal
+
+Pop is a command-line tool for sending email. This skill covers non-interactive
+usage.
+
+## Setup
+
+Pop supports three delivery methods. Configure exactly one.
+
+### Resend OAuth (recommended)
+
+    pop auth
+
+Authenticates with Resend via OAuth 2.0 in the browser. Tokens are stored
+locally and reused automatically on subsequent sends, so this only needs to be
+run once.
+
+Revoke with:
+
+    pop auth revoke
+
+### Resend API Key
+
+Set RESEND_API_KEY in the environment, or pass --resend.key.
+
+    export RESEND_API_KEY=re_xxxxxxxx
+
+### SMTP
+
+    export POP_SMTP_HOST=smtp.gmail.com
+    export POP_SMTP_PORT=587
+    export POP_SMTP_USERNAME=you@example.com
+    export POP_SMTP_PASSWORD=secret
+    export POP_SMTP_ENCRYPTION=starttls
+
+Encryption options: starttls (default), ssl, none.
+
+### Other Environment Variables
+
+    POP_FROM          Default sender address
+    POP_SIGNATURE     Signature appended to the email body
+    POP_UNSAFE_HTML   Set to "true" to allow unsafe HTML and extra markdown features
+
+## Sending Email (Non-Interactive)
+
+When --to, --from, --subject, and a body are ALL provided and --preview is NOT
+set, Pop sends immediately without launching the TUI.
+
+Body via stdin:
+
+    pop < message.md --from me@example.com --to you@example.com --subject "Hello"
+
+Body via flag:
+
+    pop --body "Hello there" --from me@example.com --to you@example.com --subject "Hello"
+
+### Flags
+
+    -f, --from         Sender address (env POP_FROM)
+    -t, --to           Recipients (comma-separated or repeatable)
+        --cc           CC recipients
+        --bcc          BCC recipients
+    -s, --subject      Email subject
+    -b, --body         Email body (Markdown, rendered to HTML)
+    -a, --attach       Attach a file (repeatable)
+    -x, --signature    Signature appended to body (env POP_SIGNATURE)
+    -u, --unsafe       Allow unsafe HTML / extra markdown features (env POP_UNSAFE_HTML)
+        --preview      Open the TUI to review before sending
+
+### Attachments
+
+    pop --attach invoice.pdf --attach report.docx \
+        --from me@example.com --to client@example.com \
+        --subject "Documents" --body "See attached."
+
+## Composing with Other Tools
+
+Pipe generated content from another CLI tool into pop:
+
+    pop <<< "$(crush run 'Write a welcome email')" \
+        --subject "Welcome" --from me@example.com --to you@example.com
+
+## Notes
+
+- The body is Markdown, rendered to HTML before sending.
+- If both Resend and SMTP are configured, Pop errors — set only one.
+- Gmail users: host/port default automatically when the username ends in
+  @gmail.com.
+- If --preview is set or any required field is missing, the interactive TUI
+  launches instead.


### PR DESCRIPTION
This revision adds a bunch of small adjustments to make Pop work well with AI agents.

Most notably, there's now a `pop skill` command which will print a skill to `stdout`:

<a><img width="700" src="https://github.com/user-attachments/assets/0b55409f-023a-4ce4-b627-8eb7202eada0" /></p>

There’s also a `pop install-skill` command which will install the pop skill to a number of known AI agents.

<p><img width="633" src="https://github.com/user-attachments/assets/0664f7cd-9172-4712-b988-bf4b6f4114e3" /></p>
