### PR TITLE
build: bump Go to 1.26.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,8 @@ jobs:
           go-version: ^1
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
+        env:
+          GOTOOLCHAIN: auto
         with:
           # Optional: golangci-lint command line arguments.
           args: --issues-exit-code=0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/charmbracelet/pop
 
-go 1.26.4
+go 1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
Just to address https://pkg.go.dev/vuln/GO-2026-5856 reported by govulncheck